### PR TITLE
chore(dev): setup Husky with pre-commit hook + check commit lint

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no -- commitlint --edit "$1"

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,2 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
+#!/usr/bin/env sh
 npx --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,3 @@
+#"$(dirname "$0")/_/husky.sh"
+
+npm test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,1 @@
-#"$(dirname "$0")/_/husky.sh"
-
 npm test

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+export default { extends: ['@commitlint/config-conventional'] };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "@adonisjs/eslint-config": "^2.0.0",
     "@adonisjs/prettier-config": "^1.4.0",
     "@adonisjs/tsconfig": "^1.4.0",
+    "@commitlint/cli": "^19.8.1",
+    "@commitlint/config-conventional": "^19.8.1",
     "@japa/api-client": "^3.1.0",
     "@japa/assert": "^4.0.1",
     "@japa/plugin-adonisjs": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "format": "prettier --write .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "prepare": "husky"
   },
   "imports": {
     "#controllers/*": "./app/controllers/*.js",
@@ -46,6 +47,7 @@
     "@types/node": "^22.13.2",
     "eslint": "^9.26.0",
     "hot-hook": "^0.4.0",
+    "husky": "^9.1.7",
     "pino-pretty": "^13.0.0",
     "prettier": "^3.5.0",
     "ts-node-maintained": "^10.9.5",


### PR DESCRIPTION
**Objectif**

- Bloquer les commits qui ne respectent pas la convention (feat:, fix:, etc.)
- Exécuter les tests automatiquement avant chaque commit (pre-commit)
- Renforcer la cohérence et la lisibilité de l’historique Git du projet

**Détails des modifications**
- Installation de husky en tant que dépendance de développement
- Ajout du script prepare dans le package.json ("prepare": "husky")
- Initialisation du dossier `.husky/`
- Création des hooks :
  - `pre-commit` : exécute `npm test`
  - `commit-msg` : valide le message avec commitlint
- Installation de :
  - `@commitlint/cli`
  - `@commitlint/config-conventional`
- Création du fichier `commitlint.config.js `avec la configuration standard

**Résultat**
- Les commits invalides sont bloqués localement
- Les tests sont automatiquement lancés avant chaque commit
- L’équipe adopte une convention commune sur les messages Git
- Intégration simple, légère, et extensible pour d’autres hooks (pre-push, lint-staged, etc.)