### PR TITLE
feat(planning): adding planning reader and creation

### DIFF
--- a/app/controllers/plannings_controller.ts
+++ b/app/controllers/plannings_controller.ts
@@ -1,0 +1,47 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { inject } from '@adonisjs/core'
+import { ErrorHandlerService } from '#services/error_handler_service'
+import { createPlanningValidator, getPlanningDuringPeriod } from '#validators/planning_validator'
+import { CreatePlanningRequestDTO, GetPlanningDuringPeriodRequestDTO } from '#types/planning_types'
+import PlanningMapper from '#mappers/planning_mapper'
+import PlanningService from '#services/planning_service'
+
+@inject()
+export default class PlaningController {
+  private readonly errorHandler: ErrorHandlerService
+
+  constructor(private planningService: PlanningService) {
+    this.errorHandler = new ErrorHandlerService()
+  }
+
+  async index({ request, response }: HttpContext) {
+    try {
+      console.log('Fetching planning data')
+      const data = { queries: request.qs() }
+      const planningRequestDTO: GetPlanningDuringPeriodRequestDTO =
+        await getPlanningDuringPeriod.validate(data)
+      const planningData = PlanningMapper.fromPlanningDuringPeriodRequestDTO(planningRequestDTO)
+      const plannings = await this.planningService.getPlanningDuringPeriod(planningData)
+      return response.ok(plannings)
+    } catch (error) {
+      this.errorHandler.handle(error, { request, response }, 'fetch talk data')
+    }
+  }
+
+  async store({ request, response }: HttpContext) {
+    try {
+      const data = request.all()
+      const requestDTO: CreatePlanningRequestDTO = await createPlanningValidator.validate(data)
+      const planningData = PlanningMapper.fromCreateDTO(requestDTO)
+
+      const planning = await this.planningService.createPlanning(
+        planningData,
+        requestDTO.roomId,
+        requestDTO.talkId
+      )
+      return response.created(planning)
+    } catch (error) {
+      this.errorHandler.handle(error, { request, response }, 'create talk')
+    }
+  }
+}

--- a/app/mappers/planning_mapper.ts
+++ b/app/mappers/planning_mapper.ts
@@ -1,0 +1,21 @@
+import Planning from '#models/planning'
+import { CreatePlanningRequestDTO, GetPlanningDuringPeriodRequestDTO } from '#types/planning_types'
+import { DateTime } from 'luxon'
+
+export default class PlanningMapper {
+  static fromPlanningDuringPeriodRequestDTO(dto: GetPlanningDuringPeriodRequestDTO): Planning {
+    const planning = new Planning()
+    planning.startTime = DateTime.fromJSDate(new Date(dto.queries.startDate))
+    planning.endTime = DateTime.fromJSDate(new Date(dto.queries.endDate))
+    return planning
+  }
+
+  static fromCreateDTO(dto: CreatePlanningRequestDTO): Planning {
+    const planning = new Planning()
+    planning.startTime = DateTime.fromJSDate(dto.startDateTime)
+    planning.endTime = DateTime.fromJSDate(dto.endDateTime)
+    // planning.countPlaces = 0
+    // planning.isFull = false
+    return planning
+  }
+}

--- a/app/models/planning.ts
+++ b/app/models/planning.ts
@@ -1,8 +1,9 @@
 import { DateTime } from 'luxon'
-import { BaseModel, column, belongsTo } from '@adonisjs/lucid/orm'
+import { BaseModel, column, belongsTo, afterCreate } from '@adonisjs/lucid/orm'
 import type { BelongsTo } from '@adonisjs/lucid/types/relations'
 import Talk from '#models/talk'
 import Room from '#models/room'
+import { TalkStatus } from '#enums/talks_enums'
 
 export default class Planning extends BaseModel {
   @column({ isPrimary: true })
@@ -37,4 +38,11 @@ export default class Planning extends BaseModel {
 
   @column.dateTime({ autoCreate: true, autoUpdate: true })
   declare updatedAt: DateTime
+
+  @afterCreate()
+  public static async updateTalkStatus(planning: Planning) {
+    const talk = await Talk.findOrFail(planning.talkId)
+    talk.statusId = TalkStatus.APPROVED
+    await talk.save()
+  }
 }

--- a/app/services/planning_service.ts
+++ b/app/services/planning_service.ts
@@ -1,0 +1,29 @@
+import Planning from '#models/planning'
+import Room from '#models/room'
+import Talk from '#models/talk'
+
+export default class PlanningService {
+  public async getPlanningDuringPeriod(planning: Planning): Promise<Planning[]> {
+    return Planning.query()
+      .where('start_time', '>=', planning.startTime.toString()) // Luxon -> SQL format
+      .andWhere('end_time', '<=', planning.endTime.toString())
+      .preload('talk')
+      .preload('room')
+  }
+
+  public async createPlanning(
+    planning: Planning,
+    roomId: number,
+    talkId: number
+  ): Promise<Planning> {
+    planning.countPlaces = 0
+    planning.isFull = false
+
+    const talk = await Talk.findOrFail(talkId)
+    const room = await Room.findOrFail(roomId)
+    await planning.related('talk').associate(talk)
+    await planning.related('room').associate(room)
+
+    return await planning.save()
+  }
+}

--- a/app/services/talk_service.ts
+++ b/app/services/talk_service.ts
@@ -28,7 +28,7 @@ export default class TalkService {
     const speaker = await User.findOrFail(speakerId)
     const level = await Level.findOrFail(levelId)
     const type = await Type.findOrFail(typeId)
-    const status = await Status.findOrFail(1)
+    const status = await Status.findOrFail(TalkStatus.PENDING)
 
     await talk.related('speaker').associate(speaker)
     await talk.related('level').associate(level)

--- a/app/types/planning_types.ts
+++ b/app/types/planning_types.ts
@@ -1,0 +1,13 @@
+export interface GetPlanningDuringPeriodRequestDTO {
+  queries: {
+    startDate: string
+    endDate: string
+  }
+}
+
+export interface CreatePlanningRequestDTO {
+  startDateTime: Date
+  endDateTime: Date
+  roomId: number
+  talkId: number
+}

--- a/app/validators/planning_validator.ts
+++ b/app/validators/planning_validator.ts
@@ -1,0 +1,18 @@
+import vine from '@vinejs/vine'
+
+export const getPlanningDuringPeriod = vine.compile(
+  vine.object({
+    queries: vine.object({
+      startDate: vine.string(),
+      endDate: vine.string(),
+    }),
+  })
+)
+export const createPlanningValidator = vine.compile(
+  vine.object({
+    startDateTime: vine.date().transform((date) => new Date(date)),
+    endDateTime: vine.date().transform((date) => new Date(date)),
+    roomId: vine.number().positive(),
+    talkId: vine.number().positive(),
+  })
+)

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -5,6 +5,7 @@ const ApiInfoController = () => import('#controllers/api_info_controller')
 const TalksController = () => import('#controllers/talks_controller')
 const TypesController = () => import('#controllers/types_controller')
 const RoomsController = () => import('#controllers/rooms_controller')
+const PlanningsController = () => import('#controllers/plannings_controller')
 
 router.get('/', [RootController])
 router.get('/health', [HealthCheckController])
@@ -15,6 +16,7 @@ router
       .group(() => {
         router.get('/', [ApiInfoController])
         router.get('/types', [TypesController, 'index'])
+        router.get('/plannings', [PlanningsController, 'index'])
         router
           .group(() => {
             router.post('/types', [TypesController, 'store'])
@@ -29,7 +31,7 @@ router
             router.get('/talks', [TalksController, 'pending'])
             router.get('/talks/:id', [TalksController, 'show'])
             router.put('/talks/:id/refused', [TalksController, 'refused'])
-            router.delete('/talks/:id', [TalksController, 'destroy'])
+            router.post('/plannings', [PlanningsController, 'store'])
           })
           .prefix('organizer')
         router


### PR DESCRIPTION
## 📝 Description

Add planning creation and reader

Related task : [BAB-60](https://gofast-cdn.atlassian.net/browse/BAB-60?atlOrigin=eyJpIjoiYmFhMDMwZTM2MzI2NGRlMWFhOTdkNzFmNzAzZDI1YTEiLCJwIjoiaiJ9)

## ✅ Checklist

- [ ] GET /api/organizer/talks get all pending talks
- [ ] GET /api/organizer/talks/:id get talk detail
- [ ] PATCH /api/organizer/talks/:id/refused refused talk
- [ ] POST /api/organizer/plannings create a planning and update talks status
- [ ] GET /api/plannings get all plannings planned
- [ ] Validation des données entrantes selon le schéma de type et params
- [ ] Réponses API bien formatées avec codes HTTP appropriés
- [ ] Error handler approprié 
- [ ] Tests des controler et services

## 📋 Notes for reviewers

RAS


[BAB-60]: https://gofast-cdn.atlassian.net/browse/BAB-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ